### PR TITLE
Add Condition to recommended Import

### DIFF
--- a/src/Endjin.RecommendedPractices.NuGet/Endjin.RecommendedPractices.nuspec
+++ b/src/Endjin.RecommendedPractices.NuGet/Endjin.RecommendedPractices.nuspec
@@ -5,7 +5,7 @@
         <id>Endjin.RecommendedPractices</id>
 
         <!-- This is overridden by the automatic build. It is present here to avoid validation failures. -->
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <description>Applies endjin standard practices to a .NET project.</description>
         <authors>endjin</authors>
 

--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.VerifyImport.targets
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.VerifyImport.targets
@@ -12,7 +12,7 @@
     <Target Name="_EndjinCheckImport">
         <Error
             Condition=" ('$(_EndjinProjectPropsImported)' != 'true') And ($(EndjinSuppressPropsImportError) != 'true') "
-            Text="When using the Endjin.RecommendedPractices NuGet package, you must add &lt;Import Project=&quot;%24(EndjinProjectPropsPath)&quot; /&gt; at the top of your csproj file"
+            Text="When using the Endjin.RecommendedPractices NuGet package, you must add &lt;Import Project=&quot;%24(EndjinProjectPropsPath)&quot; Condition=&quot;%24(EndjinProjectPropsPath) != ''&quot; /&gt; at the top of your csproj file"
         />
     </Target>
 </Project>


### PR DESCRIPTION
When you first add `Endjin.RecommendedPractices` it tells you to add a particular `<Import>` element to the top of your project file. However, it turns out that the recommendation is not correct. The import needs to be conditional, because of the way `dotnet restore` (and also the restore phase of `dotnet build`) works.

`Endjin.RecommendedPractices` depends on the .NET SDK's ability to import assets from NuGet packages as part of the build process. But for that to work, it first needs to discover what NuGet packages it is going to include. The `dotnet` seems to do this by evaluating the project file in a preliminary mode where it runs all explicit `<Import>` elements in the project file, but does not run any of the NuGet build assets (because it doesn't yet know what packages are in use). This determines the set of imports, and for the main build it evaluates the project again, this time including any build assets from the NuGet packages the project depends on.

The problem for us is that the `$(EndjinProjectPropsPath)` is not set during this initial restore-phase project file evaluation, and so the import our package asks you to add:

```xml
<Import Project="$(EndjinProjectPropsPath)" />
```

fails. (For some reason this doesn't happen in Visual Studio. It must be evaluting the package references in some other way.)

We need the import to be conditional, so that it gets skipped in these restore-phase evaluations:

```xml
<Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
```

This PR modifies the message the package produces so that it tells you the correct line to add.

Resolves #7