### PR TITLE
Fix source code links

### DIFF
--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.GitHub.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.GitHub.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <GitHubOrg>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/]*)`).Groups[1].Value)</GitHubOrg>
     <GitHubProject>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/]*)`).Groups[2].Value)</GitHubProject>
-    <GitHubCommit>$(EndjinCommitSha)</GitHubCommit>
   </PropertyGroup>
 
 </Project>

--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.GitHub.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.GitHub.props
@@ -1,8 +1,9 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <GitHubOrg>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/\.]*)`).Groups[1].Value)</GitHubOrg>
-    <GitHubProject>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/\.]*)`).Groups[2].Value)</GitHubProject>
+    <GitHubOrg>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/]*)`).Groups[1].Value)</GitHubOrg>
+    <GitHubProject>$([System.Text.RegularExpressions.Regex]::Match($(EndjinRepositoryUrl), `https://github.com/([^/]*)/([^/]*)`).Groups[2].Value)</GitHubProject>
+    <GitHubCommit>$(EndjinCommitSha)</GitHubCommit>
   </PropertyGroup>
 
 </Project>

--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
@@ -31,6 +31,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Deterministic>true</Deterministic>
+    <!-- https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables -->
+    <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">True</ContinuousIntegrationBuild>
   </PropertyGroup>
 
     <!--

--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <Authors>Endjin Limited</Authors>
     <!-- Note: Copyright property is not specific to NuGet so we set it elsewhere -->
-    <RepositoryUrl>https://github.com/$(GitHubOrg)/$(GitHubProject)</RepositoryUrl>
-    <RepositoryCommit>$(GitHubCommit)</RepositoryCommit>
+    <RepositoryUrl>https://github.com/$(GitHubOrg)/$(GitHubProject).git</RepositoryUrl>
     <PackageProjectUrl>https://github.com/$(GitHubOrg)/$(GitHubProject)</PackageProjectUrl>
     <PackageReleaseNotes>See https://github.com/$(GitHubOrg)/$(GitHubProject)/releases/</PackageReleaseNotes>
 

--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.NuGet.props
@@ -3,6 +3,7 @@
     <Authors>Endjin Limited</Authors>
     <!-- Note: Copyright property is not specific to NuGet so we set it elsewhere -->
     <RepositoryUrl>https://github.com/$(GitHubOrg)/$(GitHubProject)</RepositoryUrl>
+    <RepositoryCommit>$(GitHubCommit)</RepositoryCommit>
     <PackageProjectUrl>https://github.com/$(GitHubOrg)/$(GitHubProject)</PackageProjectUrl>
     <PackageReleaseNotes>See https://github.com/$(GitHubOrg)/$(GitHubProject)/releases/</PackageReleaseNotes>
 


### PR DESCRIPTION
The regex used for parsing the repo name from the repository URL was incorrect. It was previously only capturing up to the first `.` in the name. e.g. for `https://github.com/marain-dotnet/Marain.Claims` the repo name was coming out as `Marain` instead of `Marain.Claims`.

Also, the `RepositoryUrl` property in the proj file should have `.git` at the end of the URL.

Once this is merged, unfortunately we will have to update `Endjin.RecommendedPractices.NuGet` in all Corvus/Marain/Menes projects, push out new releases for those projects, then update all projects that reference Corvus/Marain/Menes projects in order to get source code linking working again.