### PR TITLE
Replace `DocumentationFile` property with `GenerateDocumentationFile`

### DIFF
--- a/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.Net.props
+++ b/src/Endjin.RecommendedPractices.NuGet/build/Endjin.Common.Net.props
@@ -54,11 +54,7 @@
     -->
     <LangVersion>latest</LangVersion>
 
-
-    <!--
-        If you don't specify a location for the XML documentation, it doesn't appear.
-    -->
-    <DocumentationFile>$(OutputPath)$(TargetFramework.ToLowerInvariant())\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Previously, documentation file was being generated incorrectly when using the `DocumentationFile` property. It seemed that `TargetFramework` and `AssemblyName` were evaulating to empty, which left a a documentation file which looked like `/bin/release/.xml`. This is turn was causing `dotnet pack` to fail, as it errors when trying to copy files starting with `.` by default. It also meant that the documentation was not being properly included in the nuget packages.

Using the `GenerateDocumentationFile` property will generate the documentation file in the project directory with the same root filename as the assembly (without having to explicitly set a `DocumentationFile` path property). This appears to correctly populate the target framework and assembly name in the file path.